### PR TITLE
Improve food spawning and merge drop mechanics

### DIFF
--- a/src/main.html
+++ b/src/main.html
@@ -216,17 +216,13 @@
     score: 0,
     food: [],
     hazards: [],
-    patches: [],
-    baseFoodRate: 0.04,   // Baseline / s / Fisch
-    foodRate: 0.12,       // historische Skalierung, bleibt für Balance
+    foodRate: 0.04,   // Nahrung pro Sekunde pro Fisch
     foodEnergy: 40,
     mutation: 0.10,
     difficulty: 1,
     aliveTime: 0,
     births: 0,
     deaths: 0,
-    nextWave: 6 + Math.random()*8,
-    famineUntil: 0,
     prestige: 0,
   };
 
@@ -252,48 +248,19 @@
   }
 
   // ===== Food (mit TTL) =====
-  class Food{ constructor(x,y){ this.x=x; this.y=y; this.r=3; this.energy = game.foodEnergy; this.vx = rand(-0.1,0.1); this.vy = rand(-0.02,0.02)-0.01; this.eaten=false; this.age=0; this.maxLife = rand(8,14); }
+  class Food{ constructor(x,y,maxLevel=Infinity){ this.x=x; this.y=y; this.r=3; this.energy = game.foodEnergy; this.vx = rand(-0.1,0.1); this.vy = rand(-0.02,0.02)-0.01; this.eaten=false; this.age=0; this.maxLife = 10; this.maxLevel = maxLevel; }
     update(dt){ this.x+=this.vx; this.y+=this.vy; if(this.x<8) this.x=8, this.vx*=-1; if(this.x>W-8) this.x=W-8, this.vx*=-1; if(this.y<8) this.y=8, this.vy*=-1; if(this.y>H-8) this.y=H-8, this.vy*=-1; this.age += dt; }
     get dead(){ return this.eaten || this.age>this.maxLife; }
     draw(){ const left = clamp(1 - this.age/this.maxLife, 0, 1); ctx.save(); ctx.globalAlpha = 0.4 + left*0.6; ctx.fillStyle='rgba(255,255,200,.95)'; ctx.beginPath(); ctx.arc(this.x,this.y,this.r,0,TAU); ctx.fill(); ctx.restore(); }
   }
 
-  // ===== Plankton-Patches (Wellen) =====
-  class Patch{ constructor(x,y,intensity=1, duration=9){ this.x=x; this.y=y; this.r = rand(100,180); this.intensity=intensity; this.time=0; this.duration=duration; this.acc=0; }
-    update(dt){ this.time+=dt; this.x += Math.sin(this.time*0.3)*0.15; this.y += Math.cos(this.time*0.25)*0.15; this.acc += dt * (12 * this.intensity); // 12 Partikel/s @1.0
-      while(this.acc>=1){ this.acc-=1; const ang = Math.random()*TAU; const rad = Math.pow(Math.random(),0.4)*this.r; const x=this.x+Math.cos(ang)*rad; const y=this.y+Math.sin(ang)*rad; spawnFoodAt(x,y); }
-    }
-    get dead(){ return this.time>this.duration; }
-    draw(){ ctx.save(); ctx.globalAlpha=0.08; ctx.fillStyle='rgba(170,220,255,0.45)'; ctx.beginPath(); ctx.arc(this.x,this.y,this.r,0,TAU); ctx.fill(); ctx.restore(); }
-  }
-
-  function spawnFoodAt(x,y){ game.food.push(new Food(clamp(x,12,W-12), clamp(y,12,H-12))); }
+  function spawnFoodAt(x,y,maxLevel=Infinity){ game.food.push(new Food(clamp(x,12,W-12), clamp(y,12,H-12), maxLevel)); }
 
   function updateFoodSystem(dt){
-    // Wellen-Logik
-    game.nextWave -= dt;
-    if(game.famineUntil>0){ game.famineUntil -= dt; }
-    if(game.nextWave<=0){
-      if(Math.random()<0.2 && game.famineUntil<=0){
-        // Hungersnot – kurz kaum Futter
-        game.famineUntil = rand(5,9);
-        game.nextWave = rand(8,14);
-      } else {
-        // Bloom – 1–3 Patches
-        const n = 1 + (Math.random()<0.6?1:0) + (Math.random()<0.25?1:0);
-        for(let i=0;i<n;i++) game.patches.push(new Patch(rand(80,W-80), rand(80,H-80), rand(0.8,2.0), rand(7,12)));
-        game.nextWave = rand(8,16);
-      }
-    }
-
-    // Baseline-Spawns (gedrosselt bei Hungersnot)
-    const baseRate = game.baseFoodRate * Math.max(boids.length, START_FISH) * (game.famineUntil>0?0.15:1);
-    baseAcc += dt * baseRate;
+    for(const f of game.food) f.update(dt);
+    const rate = game.foodRate * Math.max(boids.length, START_FISH);
+    baseAcc += dt * rate;
     while(baseAcc>=1){ baseAcc-=1; spawnFoodAt(rand(20,W-20), rand(20,H-20)); }
-
-    // Patches updaten
-    for(const p of game.patches) p.update(dt);
-    game.patches = game.patches.filter(p=>!p.dead);
   }
 
   // ===== Hazards =====
@@ -344,6 +311,7 @@
       };
       this.energy = rand(45,70);
       this.breedCooldown = 0;
+      this.dropAcc = rand(0,5);
       this.age = 0;
       this.wobblePhase = rand(0,TAU);
       assignArchetype(this);
@@ -369,12 +337,13 @@
       this.energy -= costBase * dt;
       this.breedCooldown = Math.max(0, this.breedCooldown - dt);
       this.age += dt;
+      if(this.level>1){ this.dropAcc += dt; if(this.dropAcc >= 5){ this.dropAcc = 0; spawnFoodAt(this.x, this.y, this.level-1); } }
     }
     tryEat(foodQt){
       const eatR = 16;
       const range = new Rect(this.x-eatR, this.y-eatR, eatR*2, eatR*2);
       const nearby = foodQt.query(range);
-      for(const f of nearby){ const d = Math.hypot(this.x-f.x, this.y-f.y); if(d < eatR+f.r && !f.eaten){ f.eaten=true; this.energy += f.energy * Math.pow(10, this.level-1); game.score += 2; return; } }
+      for(const f of nearby){ const d = Math.hypot(this.x-f.x, this.y-f.y); if(d < eatR+f.r && !f.eaten && this.level <= f.maxLevel){ f.eaten=true; this.energy += f.energy * Math.pow(10, this.level-1); game.score += 2; return; } }
     }
     maybeBreed(){
       const need = 110 / this.genes.fertility;
@@ -652,7 +621,7 @@
     statsAcc += dt; if(statsAcc>=0.5){ statsAcc=0; renderStats(); }
     hoverAcc += dt; if(hoverAcc>=0.12){ hoverAcc=0; if(hoverFish) updateTooltip(); }
 
-    // Food-System (Wellen, TTL, Hungersnot)
+    // Food-System (zufälliger Spawn mit TTL)
     updateFoodSystem(dt);
 
     exTime += dt; if(excitement>0){ const halfLife=4; excitement *= Math.pow(0.5, dt/halfLife); if(excitement<0.001) excitement=0; }
@@ -675,10 +644,9 @@
       b.maybeBreed(); if(b.energy<=0){ boids.splice(i,1); game.deaths+=1; } else b.draw(ctx);
     }
 
-    // Food & Patches draw
+    // Food & Hazards draw
     for(const f of game.food) f.draw();
     for(const h of game.hazards) h.draw();
-    for(const p of game.patches) p.draw();
 
     // Obstacles (falls mal benutzt)
     ctx.save(); ctx.globalAlpha=0.25; ctx.fillStyle='rgba(200,220,255,0.15)'; ctx.strokeStyle='rgba(200,220,255,0.35)'; for(const o of obstacles){ ctx.beginPath(); ctx.arc(o.x,o.y,o.r,0,TAU); ctx.fill(); ctx.stroke(); } ctx.restore();
@@ -695,7 +663,7 @@
     requestAnimationFrame(loop);
   }
 
-  function updateBadges(){ popBadge.textContent = `${boids.length} Fische`; roundBadge.textContent = `Runde ${game.round}`; scoreBadge.textContent = `Score ${game.score}`; prestigeBadge.textContent = `Prestige ${game.prestige}`; const secs = Math.max(0, Math.ceil(game.roundDuration - game.time)); const famine = game.famineUntil>0? ' • Hungersnot!':''; hud.textContent = `${boids.length} Fische • Runde ${game.round} • noch ${secs}s • Score ${game.score}${famine}`; }
+  function updateBadges(){ popBadge.textContent = `${boids.length} Fische`; roundBadge.textContent = `Runde ${game.round}`; scoreBadge.textContent = `Score ${game.score}`; prestigeBadge.textContent = `Prestige ${game.prestige}`; const secs = Math.max(0, Math.ceil(game.roundDuration - game.time)); hud.textContent = `${boids.length} Fische • Runde ${game.round} • noch ${secs}s • Score ${game.score}`; }
 
   function autoQuality(){ if(fps < 50){ quality.stripes = 3; quality.dust = 70; params.viewRadius = 54; } else if(fps > 58){ quality.stripes = turboOn ? 4 : 6; quality.dust = turboOn ? 100 : 130; params.viewRadius = turboOn ? 56 : 60; } }
 
@@ -710,7 +678,7 @@
 
   const CARDS = [
     {id:'food+', title:'Mehr Plankton', desc:'+25% Nahrung pro Spawn', apply:()=>{ game.foodEnergy*=1.25; }},
-    {id:'foodrate+', title:'Planktonblüte', desc:'+30% Nahrungsspawnrate', apply:()=>{ game.baseFoodRate*=1.3; }},
+    {id:'foodrate+', title:'Planktonblüte', desc:'+30% Nahrungsspawnrate', apply:()=>{ game.foodRate*=1.3; }},
     {id:'met-', title:'Effiziente Körper', desc:'-12% Energieverbrauch', apply:()=>{ for(const b of boids){ b.genes.metabolism*=0.88; } }},
     {id:'vision+', title:'Scharfe Sinne', desc:'+12% Sichtweite (Gene)', apply:()=>{ for(const b of boids){ b.genes.vision*=1.12; } }},
     {id:'coh+', title:'Schwarmgefühl', desc:'+15% Kohäsion (Gene)', apply:()=>{ for(const b of boids){ b.genes.cohesion*=1.15; } }},
@@ -720,7 +688,6 @@
     {id:'leaderAura', title:'Leader-Aura', desc:'+25% Anziehung durch Leader', apply:()=>{ params.leaderPull*=1.25; }},
     {id:'predslow', title:'Räuberbremse', desc:'-10% Räuberspeed', apply:()=>{ for(const p of predators){ p.maxSpeed*=0.9; p.baseSpeed*=0.9;} }},
     {id:'colorAffinity', title:'Farbspezialisierung', desc:'+20% Farb-Clusterung', apply:()=>{ params.colorAffinity*=1.2; }},
-    {id:'bloom+', title:'Plankton-Patches', desc:'+1 simultaner Patch', apply:()=>{ game.patches.push(new Patch(rand(80,W-80), rand(80,H-80), rand(0.8,1.6), rand(9,14))); }},
   ];
 
   function pickCards(n=3){
@@ -737,7 +704,7 @@
   function startRound(){ game.time=0; game.running=true; }
   function endRound(){ game.running=false; paused=true; showCards(`Runde ${game.round} geschafft!`, 'Wähle 1 Upgrade für den Schwarm'); }
   function startNextRound(){ game.round++; game.difficulty = 1 + (game.round-1)*0.22;
-    game.foodRate = Math.max(0.08, game.foodRate * 0.98);
+    game.foodRate = Math.max(0.02, game.foodRate * 0.98);
     const addPred = (game.round>=2) ? Math.floor((game.round-1)/2) : 0; // R2:1, R4:2, R6:3...
     spawnPredators(addPred);
     if(game.round>=2) game.hazards.push(new Hazard());
@@ -748,7 +715,7 @@
   function gameOver(){ game.running=false; paused=true; showCards('Game Over', `Score: ${game.score}. Nochmal?`);
     cardsBox.innerHTML=''; const restart = document.createElement('div'); restart.className='card'; restart.innerHTML='<h3>Neustart</h3><p>Starte einen neuen Lauf (10 Fische, Basis-Settings).</p>'; const btn=document.createElement('button'); btn.textContent='Neu starten'; btn.onclick=()=>{ restartRun(); hideModal(); }; restart.appendChild(btn); cardsBox.appendChild(restart); const prestigeCard = document.createElement('div'); prestigeCard.className='card'; prestigeCard.innerHTML='<h3>Prestige</h3><p>Reset mit dauerhaft +10% Nahrung.</p>'; const pbtn=document.createElement('button'); pbtn.textContent='Prestige'; pbtn.onclick=()=>{ prestige(); hideModal(); }; prestigeCard.appendChild(pbtn); cardsBox.appendChild(prestigeCard);
   }
-  function restartRun(){ boids=[]; predators=[]; obstacles.length=0; game.food=[]; game.hazards=[]; game.patches=[]; game.round=1; game.score=0; const bonus = 1 + game.prestige*0.1; game.baseFoodRate=0.04*bonus; game.foodRate=0.12; game.foodEnergy=40*bonus; game.mutation=0.10; game.births=0; game.deaths=0; game.nextWave=6+Math.random()*8; game.famineUntil=0; spawnFish(START_FISH); paused=false; startRound(); updateBadges(); }
+  function restartRun(){ boids=[]; predators=[]; obstacles.length=0; game.food=[]; game.hazards=[]; game.round=1; game.score=0; const bonus = 1 + game.prestige*0.1; game.foodRate=0.04*bonus; game.foodEnergy=40*bonus; game.mutation=0.10; game.births=0; game.deaths=0; spawnFish(START_FISH); paused=false; startRound(); updateBadges(); }
   function prestige(){ game.prestige++; restartRun(); }
 
   // ===== Particles =====


### PR DESCRIPTION
## Summary
- Spawn food randomly across the world instead of in circular patches
- Merged fish periodically drop food that only lower-level fish can eat
- Food items expire after 10 seconds

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f9c95c7dc832bbbc63f32fb6e9a4e