### PR TITLE
feat: track food per second goals

### DIFF
--- a/src/main.html
+++ b/src/main.html
@@ -73,7 +73,8 @@
       <div class="badges">
         <span class="badge" id="popBadge">0 Fische</span>
         <span class="badge" id="roundBadge">Runde 1</span>
-        <span class="badge" id="scoreBadge">Score 0</span>
+        <span class="badge" id="scoreBadge">Score 0/s</span>
+        <span class="badge" id="goalBadge">Ziel 1/s</span>
         <span class="badge" id="prestigeBadge">Prestige 0</span>
         <span class="badge" id="fpsBadge">60 FPS</span>
       </div>
@@ -214,6 +215,9 @@
     roundDuration: 38,
     running: true,
     score: 0,
+    foodEaten: 0,
+    roundFood: 0,
+    goal: 1,
     food: [],
     patches: [],
     baseFoodRate: 0.04,   // Baseline / s / Fisch
@@ -405,7 +409,8 @@
           if(f.energy <= 0.5){ f.eaten = true; f.energy = 0; }
           else{ f.r = 2 + (f.energy / f.maxEnergy) * 2; }
           this.energy += taken * Math.pow(10, this.level-1);
-          game.score += 2;
+          game.foodEaten += taken;
+          game.roundFood += taken;
           return;
         }
       }
@@ -418,7 +423,6 @@
         child.energy = 42;
         boids.push(child);
         enforceLeaderQuota();
-        game.score += 8;
         game.births += 1;
         this.breedCooldown = 8;
       }
@@ -705,7 +709,18 @@
     requestAnimationFrame(loop);
   }
 
-  function updateBadges(){ popBadge.textContent = `${boids.length} Fische`; roundBadge.textContent = `Runde ${game.round}`; scoreBadge.textContent = `Score ${game.score}`; prestigeBadge.textContent = `Prestige ${game.prestige}`; const secs = Math.max(0, Math.ceil(game.roundDuration - game.time)); const famine = game.famineUntil>0? ' • Hungersnot!':''; hud.textContent = `${boids.length} Fische • Runde ${game.round} • noch ${secs}s • Score ${game.score}${famine}`; }
+  function updateBadges(){
+    const foodRate = game.time>0 ? game.roundFood / game.time : 0;
+    game.score = foodRate;
+    popBadge.textContent = `${boids.length} Fische`;
+    roundBadge.textContent = `Runde ${game.round}`;
+    scoreBadge.textContent = `Score ${foodRate.toFixed(2)}/s`;
+    goalBadge.textContent = `Ziel ${game.goal.toFixed(2)}/s`;
+    prestigeBadge.textContent = `Prestige ${game.prestige}`;
+    const secs = Math.max(0, Math.ceil(game.roundDuration - game.time));
+    const famine = game.famineUntil>0? ' • Hungersnot!':'';
+    hud.textContent = `${boids.length} Fische • Runde ${game.round} • noch ${secs}s • ${foodRate.toFixed(2)}/s Nahrung • Ziel ${game.goal.toFixed(2)}/s${famine}`;
+  }
 
   function autoQuality(){ if(fps < 50){ quality.stripes = 3; quality.dust = 70; params.viewRadius = 54; } else if(fps > 58){ quality.stripes = turboOn ? 4 : 6; quality.dust = turboOn ? 100 : 130; params.viewRadius = turboOn ? 56 : 60; } }
 
@@ -753,16 +768,23 @@
   }
   function hideModal(){ modal.classList.remove('show'); }
 
-  function startRound(){ game.time=0; game.running=true; }
-  function endRound(){ game.running=false; paused=true; showCards(`Runde ${game.round} geschafft!`, 'Wähle 1 Upgrade für den Schwarm'); }
-  function startNextRound(){ game.round++; game.difficulty = 1 + (game.round-1)*0.22;
+  function startRound(){ game.time=0; game.roundFood=0; game.running=true; }
+  function endRound(){
+    game.running=false;
+    const rate = game.roundFood / game.roundDuration;
+    game.score = rate;
+    if(rate < game.goal){ gameOver(); return; }
+    paused=true;
+    showCards(`Runde ${game.round} geschafft!`, 'Wähle 1 Upgrade für den Schwarm');
+  }
+  function startNextRound(){ game.round++; game.goal += 0.5; game.difficulty = 1 + (game.round-1)*0.22;
     game.foodRate = Math.max(0.08, game.foodRate * 0.98);
     paused=false; startRound(); updateBadges(); }
 
-  function gameOver(){ game.running=false; paused=true; showCards('Game Over', `Score: ${game.score}. Nochmal?`);
+  function gameOver(){ game.running=false; paused=true; showCards('Game Over', `Score: ${game.score.toFixed(2)} Nahrung/s. Nochmal?`);
     cardsBox.innerHTML=''; const restart = document.createElement('div'); restart.className='card'; restart.innerHTML='<h3>Neustart</h3><p>Starte einen neuen Lauf (10 Fische, Basis-Settings).</p>'; const btn=document.createElement('button'); btn.textContent='Neu starten'; btn.onclick=()=>{ restartRun(); hideModal(); }; restart.appendChild(btn); cardsBox.appendChild(restart); const prestigeCard = document.createElement('div'); prestigeCard.className='card'; prestigeCard.innerHTML='<h3>Prestige</h3><p>Reset mit dauerhaft +10% Nahrung.</p>'; const pbtn=document.createElement('button'); pbtn.textContent='Prestige'; pbtn.onclick=()=>{ prestige(); hideModal(); }; prestigeCard.appendChild(pbtn); cardsBox.appendChild(prestigeCard);
   }
-  function restartRun(){ boids=[]; game.food=[]; game.patches=[]; game.round=1; game.score=0; const bonus = 1 + game.prestige*0.1; game.baseFoodRate=0.04*bonus; game.foodRate=0.12; game.foodEnergy=40*bonus; game.mutation=0.10; game.births=0; game.deaths=0; game.nextWave=6+Math.random()*8; game.famineUntil=0; spawnFish(START_FISH); paused=false; startRound(); updateBadges(); }
+  function restartRun(){ boids=[]; game.food=[]; game.patches=[]; game.round=1; game.score=0; game.foodEaten=0; game.roundFood=0; game.goal=1; const bonus = 1 + game.prestige*0.1; game.baseFoodRate=0.04*bonus; game.foodRate=0.12; game.foodEnergy=40*bonus; game.mutation=0.10; game.births=0; game.deaths=0; game.nextWave=6+Math.random()*8; game.famineUntil=0; spawnFish(START_FISH); paused=false; startRound(); updateBadges(); }
   function prestige(){ game.prestige++; restartRun(); }
 
   // ===== Particles =====
@@ -783,6 +805,7 @@
 const popBadge = document.getElementById('popBadge');
 const roundBadge = document.getElementById('roundBadge');
 const scoreBadge = document.getElementById('scoreBadge');
+const goalBadge = document.getElementById('goalBadge');
 const prestigeBadge = document.getElementById('prestigeBadge');
 const fpsBadge = document.getElementById('fpsBadge');
   turboOn = true; resize(); initDust();


### PR DESCRIPTION
## Summary
- track food eaten and compute food-per-second score
- add per-round goals and display goal badge
- gate round progression on meeting food-per-second targets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f9e8a49c0832bac806c145701ab9e